### PR TITLE
update json_api_client to greater than 1.1

### DIFF
--- a/lib/shift/api/core/version.rb
+++ b/lib/shift/api/core/version.rb
@@ -1,7 +1,7 @@
 module Shift
   module Api
     module Core
-      VERSION = "0.2.0"
+      VERSION = "0.2.1"
     end
   end
 end

--- a/shift-api-core.gemspec
+++ b/shift-api-core.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'webmock', '~> 2.3'
-  spec.add_runtime_dependency 'json_api_client', '~> 1.5'
+  spec.add_runtime_dependency 'json_api_client', '~> 1.1'
 end

--- a/shift-api-core.gemspec
+++ b/shift-api-core.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'webmock', '~> 2.3'
-  spec.add_runtime_dependency 'json_api_client', '~> 1.1'
+  spec.add_runtime_dependency 'json_api_client', '~> 1.1.1'
 end

--- a/shift-api-core.gemspec
+++ b/shift-api-core.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'webmock', '~> 2.3'
-  spec.add_runtime_dependency 'json_api_client', '~> 1.1'
+  spec.add_runtime_dependency 'json_api_client', '>= 1.1'
 end

--- a/shift-api-core.gemspec
+++ b/shift-api-core.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'webmock', '~> 2.3'
-  spec.add_runtime_dependency "json_api_client", '~> 1.1.1'
+  spec.add_runtime_dependency 'json_api_client', '~> 1.5'
 end

--- a/shift-api-core.gemspec
+++ b/shift-api-core.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'webmock', '~> 2.3'
-  spec.add_runtime_dependency 'json_api_client', '~> 1.1.1'
+  spec.add_runtime_dependency 'json_api_client', '~> 1.1'
 end

--- a/shift-api-core.gemspec
+++ b/shift-api-core.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'webmock', '~> 2.3'
-  spec.add_runtime_dependency "json_api_client", "1.1.1"
+  spec.add_runtime_dependency "json_api_client", '~> 1.1.1'
 end

--- a/shift-api-core.gemspec
+++ b/shift-api-core.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'webmock', '~> 2.3'
-  spec.add_runtime_dependency 'json_api_client', '~> 1.5'
+  spec.add_runtime_dependency "json_api_client", "1.1.1"
 end

--- a/spec/integration/custom_headers_spec.rb
+++ b/spec/integration/custom_headers_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "custom headers integration" do
     end
   end
 
+
   before(:each) { stub_request(:post, "http://test.com/v1/users").to_return(stub_response) }
 
   let(:stub_response) do


### PR DESCRIPTION
update add_runtime_dependency json_api_client work with flex-ruby-gem v0.6.55