### PR TITLE
Patch for Ruby 3 on OMS

### DIFF
--- a/lib/shift/api/core/middleware/custom_headers.rb
+++ b/lib/shift/api/core/middleware/custom_headers.rb
@@ -6,9 +6,9 @@ module Shift
         # Faraday middleware to add extra headers to the request
         #
         class CustomHeaders < ::Faraday::Middleware
-          def initialize(app, headers:)
+          def initialize(app, options = {})
             self.app = app
-            self.headers = headers
+            self.headers = options.fetch(:headers)
           end
 
           # Adds the custom headers to the passed in environment

--- a/lib/shift/api/core/version.rb
+++ b/lib/shift/api/core/version.rb
@@ -1,7 +1,7 @@
 module Shift
   module Api
     module Core
-      VERSION = "0.4.0"
+      VERSION = "0.4.1"
     end
   end
 end


### PR DESCRIPTION
## Issue

Related to: https://github.com/shiftcommerce/shift-oms/pull/1117

During the Ruby 3 upgrade for SHIFT OMS (PR above) we discovered an issue where arguments were not being passed through correctly. This was due to a problem in JSON API Client where they don't support Ruby 3 fully and so rather than submitting a possible fix for the gem itself, fixing the way we pass through parameters seems the better of the 2 options.

## Notes
- Make change manually from OMS main branch and test using Ruby 2.x to check for backwards compatibility.
- Need to bump gem version when releasing this.